### PR TITLE
Require `data-test-id` for events ['click', 'change', 'input]

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,8 @@
 name: Node.js Package
 
 on:
-  - pull_request
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -28,7 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run test
-      
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM}}
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   - push
-  - pull-request
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,32 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  - push
+  - pull-request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run test
+

--- a/lib/rules/data-test-id.js
+++ b/lib/rules/data-test-id.js
@@ -4,6 +4,10 @@
  */
 
 "use strict";
+
+const {CONSIDERED_EVENTS} = require('../Enums');
+
+
 /**
  *
  * @param {Array} arrAttributes
@@ -15,6 +19,7 @@ function isAttributePresent(arrAttributes, attributeName) {
   }
   return arrAttributes.find((attribute) => attribute.directive ? attribute.key.name.name === attributeName : attribute.key.name === attributeName);
 }
+
 
 function defineTemplateBodyVisitor(
   context,
@@ -58,6 +63,37 @@ function getVModelKey(modelExpression) {
 }
 
 
+function reportForVModel(context, node, firstToken, vModelKey) {
+  context.report({
+    node,
+    loc: firstToken.loc,
+    message: "Expected 'data-test-id' with v-model.",
+    fix: (fixer) => {
+      return fixer.insertTextAfter(firstToken, ` data-test-id="${vModelKey}"`);
+    }
+  })
+}
+
+function reportForEvent(context, node, firstToken, reportFixValye) {
+  context.report({
+    node,
+    loc: firstToken.loc,
+    message: "Expected 'data-test-id' with event.",
+    fix: (fixer) => {
+      return fixer.insertTextAfter(firstToken, ` data-test-id="${reportFixValye}"`);
+    }
+  })
+}
+
+function isConsideredEvent(objPresentEvent) {
+  if (objPresentEvent.key && objPresentEvent.key.argument && objPresentEvent.key.argument.name) {
+    return CONSIDERED_EVENTS.includes(objPresentEvent.key.argument.name);
+  }
+
+  return false;
+}
+
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -79,37 +115,49 @@ module.exports = {
   },
 
   create: function (context) {
-    const options = context.options[0] || 'always'
     const template =
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
+
     return defineTemplateBodyVisitor(context, {
       VElement(node) {
         const attributes = node.startTag.attributes;
         if (!attributes || Array.isArray(attributes) && attributes.length === 0) {
           return;
         }
+
+        if (isAttributePresent(attributes, 'data-test-id')) {
+          return;
+        }
+
+        const firstToken = template.getFirstToken(node);
+
+        /**
+         * V-model check
+         */
+
         const isModelPresent = isAttributePresent(attributes, 'model');
-        const isDataIdPresent = isAttributePresent(attributes, 'data-test-id');
-        if (isModelPresent && !isDataIdPresent) {
-          const firstToken = template.getFirstToken(node);
+        if (isModelPresent) {
           const vModelKey = getVModelKey(isModelPresent.value.expression);
-          context.report({
-            node,
-            loc: firstToken.loc,
-            message: "Expected 'data-test-id' with v-model.",
-            suggest: [
-              {
-                desc: 'Add data-test-id="unique-key"',
-                fix: (fixer) => {
-                  return fixer.insertTextAfter(firstToken, ` data-test-id="${vModelKey}"`);
-                }
-              }
-            ],
-            fix: (fixer) => {
-              return fixer.insertTextAfter(firstToken, ` data-test-id="${vModelKey}"`);
-            }
-          })
+          reportForVModel(context, node, firstToken, vModelKey);
+          return;
+        }
+
+        /**
+         * Events check: considered ['change', 'click', 'event]
+         */
+
+        const isEventPresent = isAttributePresent(attributes, 'on');
+        if (isEventPresent && isConsideredEvent(isEventPresent)) {
+          let eventFixValue = null;
+          if (isEventPresent.value && isEventPresent.value.references && Array.isArray(isEventPresent.value.references)) {
+            const eventRef = [...isEventPresent.value.references].shift();
+            eventFixValue = eventRef && eventRef.id && eventRef.id.name ? eventRef.id.name : null
+          }
+          if(eventFixValue) {
+            reportForEvent(context, node, firstToken, eventFixValue);
+            return;
+          }
         }
       }
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-test-id",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This checks is data-test-id prop is present, on some tags which are useful for e2e testing",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/data-test-id.js
+++ b/tests/lib/rules/data-test-id.js
@@ -10,7 +10,7 @@
 
 var rule = require("../../../lib/rules/data-test-id"),
 
-    RuleTester = require("eslint").RuleTester;
+  RuleTester = require("eslint").RuleTester;
 
 
 //------------------------------------------------------------------------------
@@ -19,106 +19,170 @@ var rule = require("../../../lib/rules/data-test-id"),
 
 
 const ruleTester = new RuleTester({
-    parser: require.resolve('vue-eslint-parser'),
-    parserOptions: { ecmaVersion: 2015 }
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
 })
 
 ruleTester.run('data-test-id', rule, {
-    valid: [
+  valid: [
+    {
+      filename: 'test.vue',
+      code: ''
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input data-test-id="someUniqueId" v-model="test" /></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><button data-test-id="someUniqueId" @click="doAction" >Go</button></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom data-test-id="someUniqueId" @change="doAction" >Go</custom></template>'
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="test"></template>',
+      output: '<template><input data-test-id="test" v-model="test"></template>',
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: ''
-        },
-        {
-            filename: 'test.vue',
-            code: '<template><v-btn data-test-id="test" v-model="test" /></template>'
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
         }
-    ],
+      ]
+    },
 
-    invalid: [
+    {
+      filename: 'test.vue',
+      code: '<template><custom v-model="test.again.src" /></template>',
+      output: '<template><custom data-test-id="test.again.src" v-model="test.again.src" /></template>',
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: '<template><input v-model="test"></template>',
-            output: '<template><input data-test-id="test" v-model="test"></template>',
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
 
+    {
+      filename: 'test.vue',
+      code: '<template><custom v-model="test.again" /></template>',
+      output: '<template><custom data-test-id="test.again" v-model="test.again" /></template>',
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: '<template><custom v-model="test.again.src" /></template>',
-            output: '<template><custom data-test-id="test.again.src" v-model="test.again.src" /></template>',
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
 
+    {
+      filename: 'test.vue',
+      code: `<template><custom v-model="test['again']" /></template>`,
+      output: `<template><custom data-test-id="test.again" v-model="test['again']" /></template>`,
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: '<template><custom v-model="test.again" /></template>',
-            output: '<template><custom data-test-id="test.again" v-model="test.again" /></template>',
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
 
+    {
+      filename: 'test.vue',
+      code: `<template><custom v-model="test[5]" /></template>`,
+      output: `<template><custom data-test-id="test.5" v-model="test[5]" /></template>`,
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: `<template><custom v-model="test['again']" /></template>`,
-            output: `<template><custom data-test-id="test.again" v-model="test['again']" /></template>`,
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
 
+    {
+      filename: 'test.vue',
+      code: `<template><custom v-model="test[5]['val']" /></template>`,
+      output: `<template><custom data-test-id="test.5.val" v-model="test[5]['val']" /></template>`,
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: `<template><custom v-model="test[5]" /></template>`,
-            output: `<template><custom data-test-id="test.5" v-model="test[5]" /></template>`,
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
 
+    {
+      filename: 'test.vue',
+      code: `<template><button @click="go">Save</button></template>`,
+      output: `<template><button data-test-id="go" @click="go">Save</button></template>`,
+      options: ['never'],
+      errors: [
         {
-            filename: 'test.vue',
-            code: `<template><custom v-model="test[5]['val']" /></template>`,
-            output: `<template><custom data-test-id="test.5.val" v-model="test[5]['val']" /></template>`,
-            options: ['never'],
-            errors: [
-                {
-                    message: "Expected 'data-test-id' with v-model.",
-                    type: 'VElement',
-                    line: 1
-                }
-            ]
-        },
-        
-    ]
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `<template><custom @change="go">Save</custom></template>`,
+      output: `<template><custom data-test-id="go" @change="go">Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `<template><custom @click="go">Save</custom></template>`,
+      output: `<template><custom data-test-id="go" @click="go">Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `<template><custom v-model="someModel" @change="go">Save</custom></template>`,
+      output: `<template><custom data-test-id="someModel" v-model="someModel" @change="go">Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with v-model.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+  ]
 })


### PR DESCRIPTION
Require `data-test-id` for events ['click', 'change', 'input]
This will fix with the name of event.