### PR TITLE
fix - data-test-id attribute selector

### DIFF
--- a/lib/rules/data-test-id.js
+++ b/lib/rules/data-test-id.js
@@ -17,7 +17,13 @@ function isAttributePresent(arrAttributes, attributeName) {
   if (!arrAttributes || (Array.isArray(arrAttributes) && arrAttributes.length === 0)) {
     return false;
   }
-  return arrAttributes.find((attribute) => attribute.directive ? attribute.key.name.name === attributeName : attribute.key.name === attributeName);
+  return arrAttributes.find((attribute) =>{
+    if (attribute.directive) {
+      return attribute.key.name.name === attributeName || (attribute.key.argument && attribute.key.argument.name === attributeName)
+    }
+    return attribute.key.name === attributeName
+  }
+  );
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-test-id",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-test-id",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-test-id",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "This checks is data-test-id prop is present, on some tags which are useful for e2e testing",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-test-id",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "This checks is data-test-id prop is present, on some tags which are useful for e2e testing",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/data-test-id.js
+++ b/tests/lib/rules/data-test-id.js
@@ -40,6 +40,10 @@ ruleTester.run('data-test-id', rule, {
     {
       filename: 'test.vue',
       code: '<template><custom data-test-id="someUniqueId" @change="doAction" >Go</custom></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom :data-test-id="`someUniqueId`" @change="doAction" >Go</custom></template>'
     }
   ],
 
@@ -184,5 +188,46 @@ ruleTester.run('data-test-id', rule, {
       ]
     },
 
+    {
+      filename: 'test.vue',
+      code: `<template><custom @change="go(testId)">Save</custom></template>`,
+      output: `<template><custom data-test-id="go" @change="go(testId)">Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `<template><custom @change="go(testId)" @click="onClick(testId)">Save</custom></template>`,
+      output: `<template><custom data-test-id="go" @change="go(testId)" @click="onClick(testId)">Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `<template><custom @click="onClick(testId)" @change="go(testId)" >Save</custom></template>`,
+      output: `<template><custom data-test-id="onClick" @click="onClick(testId)" @change="go(testId)" >Save</custom></template>`,
+      options: ['never'],
+      errors: [
+        {
+          message: "Expected 'data-test-id' with event.",
+          type: 'VElement',
+          line: 1
+        }
+      ]
+    },
   ]
 })


### PR DESCRIPTION
On updating new parser, `:data-test-id` selector with variable value has updated.

```
<template><input :data-test-id="'dfsf'" v-model="test"></template>
```